### PR TITLE
Fixed inconsistency in relation case sensitivity

### DIFF
--- a/engine/agnostic/predicate.go
+++ b/engine/agnostic/predicate.go
@@ -568,13 +568,14 @@ func (s *AttributeSelector) Select(cols []string, in []*list.Element) (out []*Tu
 	for attrIdx, attr := range s.attributes {
 		idx[attrIdx] = -1
 		lattr := strings.ToLower(attr)
+		lrelation := strings.ToLower(s.relation)
 		for i, c := range cols {
 			lc := strings.ToLower(c)
 			if lc == lattr {
 				idx[attrIdx] = i
 				break
 			}
-			if lc == s.relation+"."+lattr {
+			if lc == lrelation+"."+lattr {
 				idx[attrIdx] = i
 				break
 			}


### PR DESCRIPTION
### Fix AttributeSelector case sensitivity bug

#### Description:
AttributeSelector was converting table names to lowercase, but it was not converting the sought-for table name to lowercase. This resulted in the library not being able to find any tables whose names contained uppercase letters. I have fixed this issue by ensuring that the sought-for table name is also converted to lowercase before comparison.

#### Changes Made:
- Modified AttributeSelector to convert sought-for table name to lowercase for proper comparison
- Tested the fix to ensure it resolves the issue